### PR TITLE
Add merged hybrid HyperExecute YAML (mac/win/linux) for TestNG a11y

### DIFF
--- a/xml/testng_linux.xml
+++ b/xml/testng_linux.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="Linux: TestNG Execution using HyperExecute"  thread-count="1" parallel="methods">
+    <listeners>
+        <listener class-name="org.uncommons.reportng.HTMLReporter"/>
+        <listener class-name="org.uncommons.reportng.JUnitXMLReporter"/>
+    </listeners>
+
+    <test name="Test_1">
+            <parameter name="browser" value="Chrome"/>
+            <parameter name="version" value="latest"/>
+            <parameter name="platform" value="Linux"/>
+            <parameter name="resolution" value="1024x768"/>
+            <classes>
+                <class name="Test1" />
+            </classes>
+    </test>
+</suite>

--- a/xml/testng_win.xml
+++ b/xml/testng_win.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="Windows: TestNG Execution using HyperExecute"  thread-count="1" parallel="methods">
+    <listeners>
+        <listener class-name="org.uncommons.reportng.HTMLReporter"/>
+        <listener class-name="org.uncommons.reportng.JUnitXMLReporter"/>
+    </listeners>
+
+    <test name="Test_1">
+            <parameter name="browser" value="Chrome"/>
+            <parameter name="version" value="latest"/>
+            <parameter name="platform" value="Windows 10"/>
+            <parameter name="resolution" value="1024x768"/>
+            <classes>
+                <class name="Test1" />
+            </classes>
+    </test>
+</suite>

--- a/yaml/testng_hyperexecute_autosplit_sample.yaml
+++ b/yaml/testng_hyperexecute_autosplit_sample.yaml
@@ -1,0 +1,48 @@
+---
+version: 0.1
+globalTimeout: 150
+testSuiteTimeout: 150
+testSuiteStep: 150
+
+runson: ${matrix.os}
+autosplit: true
+concurrency: 1
+parallelism: 1
+
+matrix:
+  os: [mac, win, linux]
+
+env:
+  LT_ENV: ${LT_ENV}
+  hub: "${HUB_URL}"
+
+runtime:
+  language: java
+  version: 11
+
+cacheKey: '{{ checksum "pom.xml" }}'
+cacheDirectories:
+  - .m2
+
+pre:
+  - mvn -Dmaven.repo.local=./.m2 dependency:resolve
+
+# Per-OS test discovery (hybrid mode). win uses the Windows-shell hex escape
+# (\x3e) for '>'; mac/linux use plain bash sed.
+testDiscovery:
+  type: raw
+  mode: dynamic
+  command: grep 'test name' xml/testng_win.xml | awk '{print$2}' | sed 's/name=//g' | sed 's/\x3e//g'
+  macCommand: grep 'test name' xml/testng_mac.xml | awk '{print$2}' | sed 's/name=//g' | sed 's/>//g'
+  winCommand: grep 'test name' xml/testng_win.xml | awk '{print$2}' | sed 's/name=//g' | sed 's/\x3e//g'
+  linuxCommand: grep 'test name' xml/testng_linux.xml | awk '{print$2}' | sed 's/name=//g' | sed 's/>//g'
+
+# Per-OS runner. win keeps PowerShell backtick escaping; mac/linux are plain bash.
+macTestRunnerCommand: mvn test -Dplatname=mac -Dmaven.repo.local=./.m2 dependency:resolve -DselectedTests=$test
+winTestRunnerCommand: mvn test `-Dplatname=win `-Dmaven.repo.local=./.m2 dependency:resolve `-DselectedTests=$test
+linuxTestRunnerCommand: mvn test -Dplatname=linux -Dmaven.repo.local=./.m2 dependency:resolve -DselectedTests=$test
+
+retryOnFailure: true
+maxRetries: 1
+
+jobLabel: [selenium-testng, all os, hybrid, autosplit]


### PR DESCRIPTION
## What
Adds a single merged config **`yaml/testng_hyperexecute_autosplit_sample.yaml`** that runs the TestNG accessibility suite on **all three OSes** from one file, replacing the separate `yaml/mac/v1/` + `yaml/win11/v1/` configs.

Modeled on the existing `yaml/testng_hyperexecute_hybrid_sample.yaml`:
- `matrix.os: [mac, win, linux]` + `runson: ${matrix.os}`
- Per-OS discovery (`macCommand`/`winCommand`/`linuxCommand`) and per-OS runner (`macTestRunnerCommand`/`winTestRunnerCommand`/`linuxTestRunnerCommand`) so each OS keeps its own shell syntax (win PowerShell backticks/`\x3e`, mac/linux bash)
- `mode: dynamic` + explicit `parallelism: 1`/`concurrency: 1` (required for hybrid mode)

## New files
- `xml/testng_win.xml` (platform: Windows 10) and `xml/testng_linux.xml` (platform: Linux) so `-Dplatname=win|linux` resolve via pom's `xml/testng_${platname}.xml`.

## Notes
- **win11 → win**: matrix/platname now use the generic `win`.
- **linux is new/unproven**: whether the LT Selenium grid accepts the linux platform for the cloud session is a runtime unknown (`Test1.java` derives platform from `HYPEREXECUTE_PLATFORM`/xml param). mac/win are low-risk.
- Old per-OS YAMLs are left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)