### PR TITLE
Fix hybrid test discovery: portable capture-group sed (no '>' char)

### DIFF
--- a/yaml/testng_hyperexecute_autosplit_sample.yaml
+++ b/yaml/testng_hyperexecute_autosplit_sample.yaml
@@ -27,15 +27,15 @@ cacheDirectories:
 pre:
   - mvn -Dmaven.repo.local=./.m2 dependency:resolve
 
-# Per-OS test discovery (hybrid mode). win uses the Windows-shell hex escape
-# (\x3e) for '>'; mac/linux use plain bash sed.
+# Discovery extracts the test name from the suite xml. Use a capture-group
+# sed (no '>' literal/hex anywhere) so it is portable across BSD sed (mac),
+# GNU sed (linux), and the Windows discovery shell. Test names are identical
+# across the per-OS suite xmls, so one xml is enough; the runner selects the
+# right suite per OS via -Dplatname (pom: xml/testng_${platname}.xml).
 testDiscovery:
   type: raw
   mode: dynamic
-  command: grep 'test name' xml/testng_win.xml | awk '{print$2}' | sed 's/name=//g' | sed 's/\x3e//g'
-  macCommand: grep 'test name' xml/testng_mac.xml | awk '{print$2}' | sed 's/name=//g' | sed 's/>//g'
-  winCommand: grep 'test name' xml/testng_win.xml | awk '{print$2}' | sed 's/name=//g' | sed 's/\x3e//g'
-  linuxCommand: grep 'test name' xml/testng_linux.xml | awk '{print$2}' | sed 's/name=//g' | sed 's/>//g'
+  command: grep 'test name' xml/testng_mac.xml | sed -E 's/.*name="([^"]+)".*/\1/'
 
 # Per-OS runner. win keeps PowerShell backtick escaping; mac/linux are plain bash.
 macTestRunnerCommand: mvn test -Dplatname=mac -Dmaven.repo.local=./.m2 dependency:resolve -DselectedTests=$test


### PR DESCRIPTION
## Why
PR #9 merged with the original discovery command, which fails the merged hybrid run on mac (and linux):

```
/bin/bash: -c: line 0: syntax error near unexpected token `newline'
mvn test -Dplatname=mac ... -DselectedTests="Test_1">
```

The per-OS `macCommand`/`winCommand`/`linuxCommand` discovery overrides are **not applied** — every OS uses the default `command`, whose `sed 's/\x3e//g'` isn't understood by BSD sed (mac), leaving a trailing `>` in the discovered test name. That `>` reaches the runner as `-DselectedTests=Test_1>` and bash reads it as redirection.

## Fix
Single portable discovery command with **no `>` (literal or hex) anywhere**, using a capture group that works across BSD sed (mac), GNU sed (linux), and the Windows discovery shell:

```yaml
command: grep 'test name' xml/testng_mac.xml | sed -E 's/.*name="([^"]+)".*/\1/'
```

Outputs clean `Test_1`. Test names are identical across the per-OS suite xmls, so discovery reads one; the runner still selects the correct suite per OS via `-Dplatname` (pom: `xml/testng_${platname}.xml`). Removes the now-unused per-OS discovery overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)